### PR TITLE
Pade

### DIFF
--- a/Pade.sc
+++ b/Pade.sc
@@ -1,0 +1,9 @@
+Pade : Pattern{
+	*new{|freq=1, phase=0|
+		^Plazy({var undulate, result;
+			undulate = sin(2pi * freq * Ptime() + phase) % cos(2pi * freq * Ptime() + phase);
+			result = sin(4pi / exp(undulate + phase));
+			result;
+		});
+	}
+}

--- a/Psine.sc
+++ b/Psine.sc
@@ -1,6 +1,8 @@
 Psine : Pattern{
-    *new{|freq=1|
-		^Pn(sin(freq * Ptime()).abs, inf)
-    }
+	*new{|freq=1, phase=0|
+		^Plazy({ sin(2pi * freq * Ptime() + phase) });
+	}
 }
+
+
 


### PR DESCRIPTION
a type of SRP - Shifting Repetitive Patterns
Pade.sc - likes activity on the right-hand side of the decimal point

```
(
Pbind(
    \instrument, \help_sinegrain,
    \dur, 0.2,
    \sustain, Pade(1.2, 0.5).linlin(-1.0,1.0,0.03,0.8),
    \freq, Pade(Pstep([1,4,9.4,8.3], 2, inf)).linlin(-1.0,1.0,200.0,2000.0)
).play;
)

(
SynthDef(\help_sinegrain,
    { arg out = 0, freq = 440, sustain = 0.05;
        var env;
        env = EnvGen.kr(Env.perc(0.01, sustain, 0.2), doneAction: Done.freeSelf);
        Out.ar(out, SinOsc.ar(freq, 0, env))
    }).add;
)
```